### PR TITLE
Don't throw exception if AD user does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Review your LDAP configuration in the commands below and then copy-paste them:
 ## Zimbra only accounts with local password
 
 By setting `zimbraAuthFallbackToLocal` to *TRUE* you can skip AD password update, which allows creating a mailbox 
-without a corresponding user using Zimbra password backend. If you require this, it's **recommended** to enable this 
+without a corresponding user using Zimbra password backend. If you require this, it's **recommended** to enable it 
 only after successfully testing a password update against AD. 
 
 ## Support for Zentyal
@@ -71,9 +71,11 @@ ADPassword also supports Zentyal as directory server, please check the wiki:
 ## Debugging
 Do a password change while you run the following command:
 
-     tail -f /opt/zimbra/log/mailbox.log
+     tail -f /opt/zimbra/log/zmmailboxd.out
 
-Verify your configuration:     
+You should find *ADPassword* messages passing by explaining what's going on.
+
+Verify your configuration:
 
      zmprov gd domain.ext | grep -i ldap | grep -v Gal
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Review your LDAP configuration in the commands below and then copy-paste them:
 * If you want a custom password complexity rules, see: https://github.com/Zimbra-Community/ADPassword/wiki/Adding-a-password-policy-check
 * Sometimes when the user clicks the change password option, Zimbra goes to a URL on port 8443. To fix: `zmprov mcf zimbraChangePasswordURL https://your-zimbra-server.com/h/changepass?skin=harmony`
 
+## Zimbra only accounts with local password
+
+By setting `zimbraAuthFallbackToLocal` to *TRUE* you can skip AD password update, which allows creating a mailbox 
+without a corresponding user using Zimbra password backend. If you require this, it's **recommended** to enable this 
+only after successfully testing a password update against AD. 
+
 ## Support for Zentyal
 
 ADPassword also supports Zentyal as directory server, please check the wiki:

--- a/src/it/iknowconsulting/adpassword/ADConnection.java
+++ b/src/it/iknowconsulting/adpassword/ADConnection.java
@@ -64,6 +64,7 @@ public class ADConnection {
 
     public void updatePassword(Account acct, String password) throws NamingException {
         String username = acct.getUid();
+        String userTest;
         String quotedPassword = "\"" + password + "\"";
         char unicodePwd[] = quotedPassword.toCharArray();
         byte pwdArray[] = new byte[unicodePwd.length * 2];
@@ -82,11 +83,14 @@ public class ADConnection {
         else
         {
             System.out.print("ADPassword->ADConnection->updatePassword->username: "+ username);
-            System.out.print("ADPassword->ADConnection->updatePassword->fetchUser(username): "+ fetchUser(username));
+            userTest=fetchUser(username);
+            if(userTest == null)
+                return;
+            System.out.print("ADPassword->ADConnection->updatePassword->fetchUser(username): "+ userTest);
             System.out.print("ADPassword->ADConnection->updatePassword->mods: "+ mods);
-            ldapContext.modifyAttributes(fetchUser(username), mods);
+            ldapContext.modifyAttributes(userTest, mods);
         }
-    }
+    }   
 
     String fetchUser(String username) throws NamingException {
         String returnedAttrs[]={"dn"};
@@ -96,9 +100,12 @@ public class ADConnection {
         String searchFilter = authLdapSearchFilter.replace("%u",username);
         System.out.print("ADPassword->ADConnection->fetchUser->searchFilter: "+ searchFilter);
         NamingEnumeration results = ldapContext.search(authLdapSearchBase, searchFilter, searchControls);
-          
+        
+        if(results == null)
+            return null;
         SearchResult sr = (SearchResult) results.next();
         System.out.print("ADPassword->ADConnection->fetchUser->getNameInNamespace: "+ sr.getNameInNamespace());
-        return sr.getNameInNamespace();              
+        return sr.getNameInNamespace(); 
+
     }
 }

--- a/src/it/iknowconsulting/adpassword/ADConnection.java
+++ b/src/it/iknowconsulting/adpassword/ADConnection.java
@@ -90,7 +90,7 @@ public class ADConnection {
             System.out.print("ADPassword->ADConnection->updatePassword->mods: "+ mods);
             ldapContext.modifyAttributes(userTest, mods);
         }
-    }   
+    }
 
     String fetchUser(String username) throws NamingException {
         String returnedAttrs[]={"dn"};
@@ -101,7 +101,7 @@ public class ADConnection {
         System.out.print("ADPassword->ADConnection->fetchUser->searchFilter: "+ searchFilter);
         NamingEnumeration results = ldapContext.search(authLdapSearchBase, searchFilter, searchControls);
         
-        if(results == null)
+        if(!results.hasMore())
             return null;
         SearchResult sr = (SearchResult) results.next();
         System.out.print("ADPassword->ADConnection->fetchUser->getNameInNamespace: "+ sr.getNameInNamespace());


### PR DESCRIPTION
This patch (which can be squashed) allows the creation of Zimbra mailboxes without corresponding user in AD. Specifically allows setting user's password into Zimbra's LDAP, without throwing an LDAP error for the missing AD user.